### PR TITLE
feat: add option to disable proxy buffering

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+# NOTE - Vital Beats fork
+
+We use `nginx-google-oauth` to add Google Oauth to various services (griffin. prometheus, ...). However, in one case there were issues, so we forked it. The issue was with Argo workflows UI, where dynamic updates (via HTTP/2 events) failed. In this fork, we disable `proxy_buffering` to avoid the issue.
+
 # nginx-google-oauth
 
 Lua module to add Google OAuth to nginx. It is based on great work
@@ -243,6 +247,7 @@ Docker image has the following env variables for configuration:
 * `LOCATIONS` can contain `location` directives that will be injected into the
   nginx configuration on container start. If not set, a demo page is served
   under `location / {...}`.
+* `PROXY_BUFFERING_OFF`: If set (to any value) then a `proxy_buffering off` directive is added to `nginx.conf`
 
 Run the image:
 

--- a/docker/etc-nginx/run.sh
+++ b/docker/etc-nginx/run.sh
@@ -32,6 +32,12 @@ if [ "${LOCATIONS}" ]; then
   echo "${LOCATIONS}" > /etc/nginx/snippets/demo-locations.conf
 fi
 
+if [ "${PROXY_BUFFERING_OFF}" ]; then
+  # Disables buffering for reverse proxy location(s). Useful when client wants to do
+  # http/2 event streams like Argo workflows server.
+  perl -i -pe 'BEGIN{undef $/;} s/http\s*{/http {\n    proxy_buffering off;/' /etc/nginx/nginx.conf
+fi
+
 # Help people spot problems
 if [ "${DEBUG}" ]; then
   echo "## /etc/nginx/sites-available/default ##"


### PR DESCRIPTION
Adds env variable `PROXY_BUFFERING_OFF` to disables buffering for reverse proxy location(s). Useful when client wants to do http/2 event streams like Argo workflows server.

Ref: https://linear.app/vitalbeats/issue/VB-1081/fix-argo-ui-errors-with-content-security-policy